### PR TITLE
Deprecate in favor of the rwx-cloud/rwx provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Terraform Mint Provider (Deprecated)
 
 > [!WARNING]
-> **This provider is deprecated and no longer maintained.**
+> **This provider is deprecated.**
 > It has been superseded by the **RWX provider**, published as
 > [`rwx-cloud/rwx`](https://registry.terraform.io/providers/rwx-cloud/rwx) on the
-> Terraform Registry. Please migrate at your earliest convenience — this provider
-> will receive no further releases, bug fixes, or dependency updates.
+> Terraform Registry.
 
 The Mint Provider enabled [Terraform](https://terraform.io) to manage
 [RWX](https://www.rwx.com) resources (vault secrets and variables). Its

--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
-# Terraform Mint Provider
+# Terraform Mint Provider (Deprecated)
 
-The [Mint Provider](https://registry.terraform.io/providers/rwx-research/mint/latest/docs) enables [Terraform](https://terraform.io) to manage [Mint](https://www.rwx.com/mint) resources.
+> [!WARNING]
+> **This provider is deprecated and no longer maintained.**
+> It has been superseded by the **RWX provider**, published as
+> [`rwx-cloud/rwx`](https://registry.terraform.io/providers/rwx-cloud/rwx) on the
+> Terraform Registry. Please migrate at your earliest convenience — this provider
+> will receive no further releases, bug fixes, or dependency updates.
+
+The Mint Provider enabled [Terraform](https://terraform.io) to manage
+[RWX](https://www.rwx.com) resources (vault secrets and variables). Its
+functionality now lives in the RWX provider.
+
+## Where it moved
+
+| | Mint (deprecated) | RWX (current) |
+| --- | --- | --- |
+| Registry | [`rwx-research/mint`](https://registry.terraform.io/providers/rwx-research/mint) | [`rwx-cloud/rwx`](https://registry.terraform.io/providers/rwx-cloud/rwx) |
+| Source | `rwx-research/terraform-provider-mint` | [`rwx-cloud/terraform-provider-rwx`](https://github.com/rwx-cloud/terraform-provider-rwx) |
+| Provider source address | `rwx-research/mint` | `rwx-cloud/rwx` |
+| Resources | `mint_secret`, `mint_variable` | `rwx_secret`, `rwx_variable` |
+
+## Migrating
+
+The resource schemas are identical, so you can migrate existing Terraform state
+in place — no resources are destroyed or recreated. In short:
+
+1. Update `required_providers` to `source = "rwx-cloud/rwx"`, rename the
+   `provider "mint"` block to `provider "rwx"`, and rename `mint_*` resource
+   types to `rwx_*`.
+2. `terraform init`
+3. Re-point state and rename the resource types:
+   ```sh
+   terraform state replace-provider \
+     registry.terraform.io/rwx-research/mint \
+     registry.terraform.io/rwx-cloud/rwx
+   terraform state mv mint_secret.example   rwx_secret.example
+   terraform state mv mint_variable.example rwx_variable.example
+   ```
+4. `terraform plan` — it must show **no changes** before you apply.
+
+**Full step-by-step guide (including `count`/`for_each` and caveats):**
+https://registry.terraform.io/providers/rwx-cloud/rwx/latest/docs/guides/migrating-from-mint
+
+## Questions
+
+Reach out at [support@rwx.com](mailto:support@rwx.com).


### PR DESCRIPTION
Marks this provider as deprecated in favor of the **RWX provider** ([`rwx-cloud/rwx`](https://registry.terraform.io/providers/rwx-cloud/rwx)), which succeeds it.

Replaces the one-line README with a deprecation notice that:
- Adds a prominent warning banner (renders on the registry overview page)
- Maps the old → new registry namespace, source repo, provider address, and resource types
- Includes in-place state-migration steps and links to the full [migration guide](https://registry.terraform.io/providers/rwx-cloud/rwx/latest/docs/guides/migrating-from-mint)

## Notes
- The registry/guide links resolve once `rwx-cloud/rwx` is published and its migration PR is merged.
- Suggested follow-up: **archive this repo** (Settings → Archive) after merging, to make it read-only with GitHub's own archived banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
